### PR TITLE
Add support for Symfony 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "symfony/yaml": "2.1.*",
+        "symfony/yaml": "~2.1|~3.0|~4.0|~5.0",
         "chrisboulton/php-resque": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
The PR updates the `symfony/yaml` dependency to allow recent versions of the package.