### PR TITLE
Switch to `resque/php-resque`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.0",
         "symfony/yaml": "2.1.*",
-        "chrisboulton/php-resque": "dev-master"
+        "resque/php-resque": "~1.3"
     },
     "autoload": {
         "psr-0": { "Resque\\Pool": "lib/" }


### PR DESCRIPTION
PHP Resque development has moved over to the official [resque](https://github.com/resque/php-resque) organization.

Composer shows a deprecation notice when installing the original `chrisboulton/php-resque` package.