### PR TITLE
Bug fixes and Static Analysis support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/yaml": "~2.1|~3.0|~4.0|~5.0",
+        "symfony/yaml": "~2.1|~3.0|~4.0|~5.0|~6.0",
         "resque/php-resque": "~1.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "symfony/yaml": "~2.1|~3.0|~4.0|~5.0",
         "resque/php-resque": "~1.3"
     },
+    "require-dev": {
+        "phpstan/phpstan": "~1.8"
+    },
     "autoload": {
         "psr-0": { "Resque\\Pool": "lib/" }
     },
@@ -27,5 +30,8 @@
         "bin/resque-pool"
     ],
     "target-dir": "",
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "scripts": {
+        "phpstan": "phpstan analyse --memory-limit=2G"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "bin/resque-pool"
     ],
     "target-dir": "",
-    "minimum-stability": "dev",
     "scripts": {
         "phpstan": "phpstan analyse --memory-limit=2G"
     }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "symfony/yaml": "~2.1|~3.0|~4.0|~5.0",
         "resque/php-resque": "~1.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2cb2b3ffceaef30757f7f931dec12e3",
+    "content-hash": "4b825bc6929d891a1ece448031a0760d",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -187,76 +187,8 @@
             "time": "2020-04-16T16:39:50+00:00"
         },
         {
-            "name": "symfony/deprecation-contracts",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "4912000e79dc2d6df029d35d8755be1ed79b6691"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/4912000e79dc2d6df029d35d8755be1ed79b6691",
-                "reference": "4912000e79dc2d6df029d35d8755be1ed79b6691",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "default-branch": true,
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.2-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/main"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-05-20T13:56:22+00:00"
-        },
-        {
             "name": "symfony/polyfill-ctype",
-            "version": "dev-main",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -277,7 +209,6 @@
             "suggest": {
                 "ext-ctype": "For best performance"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -339,28 +270,27 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "5.4.x-dev",
+            "version": "v6.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7a3aa21ac8ab1a96cc6de5bbcab4bc9fc943b18c"
+                "reference": "cc48dd42ae1201abced04ae38284e23ce2d2d8f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7a3aa21ac8ab1a96cc6de5bbcab4bc9fc943b18c",
-                "reference": "7a3aa21ac8ab1a96cc6de5bbcab4bc9fc943b18c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/cc48dd42ae1201abced04ae38284e23ce2d2d8f3",
+                "reference": "cc48dd42ae1201abced04ae38284e23ce2d2d8f3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<5.3"
+                "symfony/console": "<5.4"
             },
             "require-dev": {
-                "symfony/console": "^5.3|^6.0"
+                "symfony/console": "^5.4|^6.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -394,7 +324,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/5.4"
+                "source": "https://github.com/symfony/yaml/tree/v6.1.3"
             },
             "funding": [
                 {
@@ -410,22 +340,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-02T15:52:22+00:00"
+            "time": "2022-07-20T14:45:06+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "phpstan/phpstan",
-            "version": "1.8.x-dev",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "47f23b1ecb5332cce428d225adac162e440dbb52"
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/47f23b1ecb5332cce428d225adac162e440dbb52",
-                "reference": "47f23b1ecb5332cce428d225adac162e440dbb52",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c53312ecc575caf07b0e90dee43883fdf90ca67c",
+                "reference": "c53312ecc575caf07b0e90dee43883fdf90ca67c",
                 "shasum": ""
             },
             "require": {
@@ -434,7 +364,6 @@
             "conflict": {
                 "phpstan/phpstan-shim": "*"
             },
-            "default-branch": true,
             "bin": [
                 "phpstan",
                 "phpstan.phar"
@@ -450,13 +379,9 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "keywords": [
-                "dev",
-                "static analysis"
-            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.8.x"
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.2"
             },
             "funding": [
                 {
@@ -468,15 +393,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-22T15:19:29+00:00"
+            "time": "2022-07-20T09:57:31+00:00"
         }
     ],
     "aliases": [],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -1,91 +1,38 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "5ab9152dd54bf1868e1eb20b719f1bec",
-    "content-hash": "6f1b2ff2695538dc3df3526813f6f7ba",
+    "content-hash": "c2cb2b3ffceaef30757f7f931dec12e3",
     "packages": [
         {
-            "name": "chrisboulton/php-resque",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/chrisboulton/php-resque.git",
-                "reference": "73b62e364a89230d041abd2ba767bcec6fa15927"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/chrisboulton/php-resque/zipball/73b62e364a89230d041abd2ba767bcec6fa15927",
-                "reference": "73b62e364a89230d041abd2ba767bcec6fa15927",
-                "shasum": ""
-            },
-            "require": {
-                "colinmollenhour/credis": "~1.2",
-                "ext-pcntl": "*",
-                "php": ">=5.3.0",
-                "psr/log": "1.0.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "3.7.*"
-            },
-            "suggest": {
-                "ext-proctitle": "Allows php-resque to rename the title of UNIX processes to show the status of a worker.",
-                "ext-redis": "Native PHP extension for Redis connectivity. Credis will automatically utilize when available."
-            },
-            "bin": [
-                "bin/resque"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Resque": "lib"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Chris Boulton",
-                    "email": "chris@bigcommerce.com"
-                }
-            ],
-            "description": "Redis backed library for creating background jobs and processing them later. Based on resque for Ruby.",
-            "homepage": "http://www.github.com/chrisboulton/php-resque/",
-            "keywords": [
-                "background",
-                "job",
-                "redis",
-                "resque"
-            ],
-            "time": "2016-03-09 21:02:55"
-        },
-        {
             "name": "colinmollenhour/credis",
-            "version": "1.7",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/colinmollenhour/credis.git",
-                "reference": "74b2b703da5c58dc07fb97e8954bc63280b469bf"
+                "reference": "85df015088e00daf8ce395189de22c8eb45c8d49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/74b2b703da5c58dc07fb97e8954bc63280b469bf",
-                "reference": "74b2b703da5c58dc07fb97e8954bc63280b469bf",
+                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/85df015088e00daf8ce395189de22c8eb45c8d49",
+                "reference": "85df015088e00daf8ce395189de22c8eb45c8d49",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=5.6.0"
+            },
+            "suggest": {
+                "ext-redis": "Improved performance for communicating with redis"
             },
             "type": "library",
             "autoload": {
                 "classmap": [
                     "Client.php",
                     "Cluster.php",
-                    "Sentinel.php"
+                    "Sentinel.php",
+                    "Module.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -100,26 +47,38 @@
             ],
             "description": "Credis is a lightweight interface to the Redis key-value store which wraps the phpredis library when available for better performance.",
             "homepage": "https://github.com/colinmollenhour/credis",
-            "time": "2016-03-24 15:50:52"
+            "support": {
+                "issues": "https://github.com/colinmollenhour/credis/issues",
+                "source": "https://github.com/colinmollenhour/credis/tree/v1.13.1"
+            },
+            "time": "2022-06-20T22:56:59+00:00"
         },
         {
             "name": "psr/log",
-            "version": "1.0.0",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.3.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Psr\\Log\\": ""
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -129,39 +88,62 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
             "keywords": [
                 "log",
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "2.1.x-dev",
-            "target-dir": "Symfony/Component/Yaml",
+            "name": "resque/php-resque",
+            "version": "v1.3.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
-                "reference": "347a7a02204433c6926ecc3f13e805bdc30e8f9f"
+                "url": "https://github.com/resque/php-resque.git",
+                "reference": "fe41c04763699b1318d97ed14cc78583e9380161"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/347a7a02204433c6926ecc3f13e805bdc30e8f9f",
-                "reference": "347a7a02204433c6926ecc3f13e805bdc30e8f9f",
+                "url": "https://api.github.com/repos/resque/php-resque/zipball/fe41c04763699b1318d97ed14cc78583e9380161",
+                "reference": "fe41c04763699b1318d97ed14cc78583e9380161",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "colinmollenhour/credis": "~1.7",
+                "php": ">=5.6.0",
+                "psr/log": "~1.0"
             },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7"
+            },
+            "suggest": {
+                "ext-pcntl": "REQUIRED for forking processes on platforms that support it (so anything but Windows).",
+                "ext-proctitle": "Allows php-resque to rename the title of UNIX processes to show the status of a worker.",
+                "ext-redis": "Native PHP extension for Redis connectivity. Credis will automatically utilize when available."
+            },
+            "bin": [
+                "bin/resque",
+                "bin/resque-scheduler"
+            ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
-                    "Symfony\\Component\\Yaml": ""
+                    "Resque": "lib",
+                    "ResqueScheduler": "lib"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -170,31 +152,337 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "name": "Dan Hunsaker",
+                    "email": "danhunsaker+resque@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Rajib Ahmed",
+                    "homepage": "https://github.com/rajibahmed",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve Klabnik",
+                    "email": "steve@steveklabnik.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Chris Boulton",
+                    "email": "chris@bigcommerce.com",
+                    "role": "Creator"
+                }
+            ],
+            "description": "Redis backed library for creating background jobs and processing them later. Based on resque for Ruby.",
+            "homepage": "http://www.github.com/resque/php-resque/",
+            "keywords": [
+                "background",
+                "job",
+                "redis",
+                "resque"
+            ],
+            "support": {
+                "issues": "https://github.com/resque/php-resque/issues",
+                "source": "https://github.com/resque/php-resque/tree/v1.3.6"
+            },
+            "time": "2020-04-16T16:39:50+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "4912000e79dc2d6df029d35d8755be1ed79b6691"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/4912000e79dc2d6df029d35d8755be1ed79b6691",
+                "reference": "4912000e79dc2d6df029d35d8755be1ed79b6691",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.2-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
                     "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "http://symfony.com",
-            "time": "2013-05-10 00:09:46"
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/main"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-20T13:56:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.26-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-24T11:49:31+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "5.4.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "7a3aa21ac8ab1a96cc6de5bbcab4bc9fc943b18c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/7a3aa21ac8ab1a96cc6de5bbcab4bc9fc943b18c",
+                "reference": "7a3aa21ac8ab1a96cc6de5bbcab4bc9fc943b18c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<5.3"
+            },
+            "require-dev": {
+                "symfony/console": "^5.3|^6.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/5.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-08-02T15:52:22+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.8.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "47f23b1ecb5332cce428d225adac162e440dbb52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/47f23b1ecb5332cce428d225adac162e440dbb52",
+                "reference": "47f23b1ecb5332cce428d225adac162e440dbb52",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "default-branch": true,
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.8.x"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-08-22T15:19:29+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "chrisboulton/php-resque": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }

--- a/lib/Resque/Pool/Cli.php
+++ b/lib/Resque/Pool/Cli.php
@@ -13,6 +13,10 @@ namespace Resque\Pool;
  */
 class Cli
 {
+
+    /**
+     * @var array<string,array<array-key,string|bool>>
+     */
     private static $optionDefs = array(
         'help' => array('Show usage information', 'default' => false, 'short' => 'h'),
         'config' => array('Alternate path to config file', 'short' => 'c'),
@@ -25,6 +29,9 @@ class Cli
         'term_immediate' => array('On TERM signal, shut down workers immediately (default)'),
     );
 
+    /**
+     * @return void
+     */
     public function run()
     {
         $opts = $this->parseOptions();
@@ -37,10 +44,18 @@ class Cli
         $this->startPool($config);
     }
 
+    /**
+     * @return array<string,mixed>
+     * @phpstan-return array{
+     *   help: bool, config: string, appName: string, daemon: bool, pidfile: string,
+     *   environment: string, term-graceful-wait: string, term-graceful: string, term_immediate: string
+     * }
+     */
     public function parseOptions()
     {
         $shortopts = '';
         $longopts = array();
+        /** @var array<string,string|bool> $defaults */
         $defaults = array();
         $shortmap = array();
 
@@ -57,6 +72,7 @@ class Cli
             }
         }
 
+        /** @var array<string,string|bool> $received */
         $received = getopt($shortopts, $longopts);
 
         foreach (array_keys($received) as $key) {
@@ -72,6 +88,7 @@ class Cli
                 $received[$key] = true;
             }
         }
+
         $received += $defaults;
 
         if ($received['help']) {
@@ -79,9 +96,12 @@ class Cli
             exit(0);
         }
 
-        return $received;
+        return $received; // @phpstan-ignore-line
     }
 
+    /**
+     * @return void
+     */
     public function usage()
     {
         $cmdname = isset($GLOBALS['argv'][0]) ? $GLOBALS['argv'][0] : 'resque-pool';
@@ -100,6 +120,9 @@ class Cli
         echo "\n\n";
     }
 
+    /**
+     * @return void
+     */
     public function daemonize()
     {
         $pid = pcntl_fork();
@@ -113,6 +136,10 @@ class Cli
         }
     }
 
+    /**
+     * @param string $pidfile
+     * @return void
+     */
     public function managePidfile($pidfile)
     {
         if (!$pidfile) {
@@ -137,13 +164,30 @@ class Cli
         });
     }
 
+    /**
+     * @param string $pidfile
+     * @return bool
+     */
     public function processStillRunning($pidfile)
     {
-        $oldPid = trim(file_get_contents($pidfile));
+        $contents = file_get_contents($pidfile);
+        if (false === $contents) {
+            return true;
+        }
+
+        $oldPid = (int)trim($contents);
 
         return posix_kill($oldPid, 0);
     }
 
+    /**
+     * @param array $options
+     * @phpstan-param array{
+     *   appName?: string, environment?: string, config?: string, daemon?: bool,
+     *   term-graceful-wait?: string, term-graceful?: string
+     * } $options
+     * @return Configuration
+     */
     public function buildConfiguration(array $options)
     {
         $config = new Configuration;
@@ -168,6 +212,9 @@ class Cli
         return $config;
     }
 
+    /**
+     * @return void
+     */
     public function startPool(Configuration $config)
     {
         $pool = new Pool($config);

--- a/lib/Resque/Pool/Cli.php
+++ b/lib/Resque/Pool/Cli.php
@@ -42,6 +42,7 @@ class Cli
         $shortopts = '';
         $longopts = array();
         $defaults = array();
+        $shortmap = array();
 
         foreach (self::$optionDefs as $name => $def) {
             $def += array('default' => '', 'short' => false);

--- a/lib/Resque/Pool/Configuration.php
+++ b/lib/Resque/Pool/Configuration.php
@@ -216,7 +216,7 @@ class Configuration
                     $queueConfig = (string)file_get_contents($this->queueConfigFile);
                 }
 
-                $this->queueConfig = Yaml::parse($queueConfig);
+                $this->queueConfig = Yaml::parse($queueConfig); // @phpstan-ignore-line
             } catch (ParseException $e) {
                 $msg = "Invalid config file: ".$e->getMessage();
                 $this->logger->log($msg);

--- a/lib/Resque/Pool/Configuration.php
+++ b/lib/Resque/Pool/Configuration.php
@@ -23,19 +23,19 @@ class Configuration
     const DEFAULT_WORKER_INTERVAL = 5;
 
     /**
-     * @param callable
+     * @var callable
      */
     public $afterPreFork;
     /**
      * Tag used in log output
      *
-     * @param string
+     * @var string
      */
     public $appName;
     /**
      * Possible configuration file locations
      *
-     * @param [string]
+     * @var [string]
      */
     public $configFiles = array('resque-pool.yml', 'config/resque-pool.yml');
     /**
@@ -45,48 +45,48 @@ class Configuration
     /**
      * Reset worker counts to 0 when SIGWINCH is received
      *
-     * @param bool
+     * @var bool
      */
     public $handleWinch = false;
     /**
-     * @param Logger
+     * @var Logger
      */
     public $logger;
     /**
-     * @param integer self::LOG_*
+     * @var integer self::LOG_*
      */
     public $logLevel = self::LOG_NONE;
     /**
-     * @param Platform
+     * @var Platform
      */
     public $platform;
     /**
      * Active configuration file location.  When null self::$configFiles will be tried.
      *
-     * @param string|null
+     * @var string|null
      */
     public $queueConfigFile;
     /**
-     * @param integer
+     * @var integer
      */
     public $sleepTime = 60;
     /**
      * What to do when receiving SIGTERM
      *
-     * @param string
+     * @var string
      */
     public $termBehavior = '';
     /**
-     * @param string
+     * @var string
      */
     public $workerClass = '\\Resque_Worker';
     /**
-     * @param integer
+     * @var integer
      */
     public $workerInterval = self::DEFAULT_WORKER_INTERVAL;
 
     /**
-     * @param [string => integer]
+     * @var array<string,int>
      */
     protected $queueConfig;
 
@@ -137,7 +137,7 @@ class Configuration
     }
 
     /**
-     * @return [string] All configured queue combinations
+     * @return string[] All configured queue combinations
      */
     public function knownQueues()
     {
@@ -145,7 +145,7 @@ class Configuration
     }
 
     /**
-     * @return [string => integer] Map of queue combination to desired worker count
+     * @return array<string,int> Map of queue combination to desired worker count
      */
     public function queueConfig()
     {
@@ -209,7 +209,7 @@ class Configuration
                 $msg = "Invalid config file: ".$e->getMessage();
                 $this->logger->log($msg);
 
-                throw new RuntimeException($msg, 0, $e);
+                throw new \RuntimeException($msg, 0, $e);
             }
         }
         if (!$this->queueConfig) {

--- a/lib/Resque/Pool/Logger.php
+++ b/lib/Resque/Pool/Logger.php
@@ -13,6 +13,7 @@ namespace Resque\Pool;
  */
 class Logger
 {
+    /** @var string */
     private $appName;
 
     public function __construct($appName = null)

--- a/lib/Resque/Pool/Logger.php
+++ b/lib/Resque/Pool/Logger.php
@@ -16,11 +16,18 @@ class Logger
     /** @var string */
     private $appName;
 
+    /**
+     * @param null|string $appName
+     */
     public function __construct($appName = null)
     {
         $this->appName = $appName ? "[{$appName}]" : "";
     }
 
+    /**
+     * @param string $string
+     * @return void
+     */
     public function procline($string)
     {
         if (function_exists('setproctitle')) {
@@ -30,12 +37,20 @@ class Logger
         }
     }
 
+    /**
+     * @param string $message
+     * @return void
+     */
     public function log($message)
     {
         $pid = getmypid();
         echo "resque-pool-manager{$this->appName}[{$pid}]: {$message}\n";
     }
 
+    /**
+     * @param string $message
+     * @return void
+     */
     public function logWorker($message)
     {
         $pid = getmypid();
@@ -44,6 +59,7 @@ class Logger
 
     /**
      * This function closes and re-opens the output log
+     * @return void
      */
     public function rotate()
     {

--- a/lib/Resque/Pool/Platform.php
+++ b/lib/Resque/Pool/Platform.php
@@ -88,7 +88,7 @@ class Platform
         if (count($this->sigQueue) < self::$SIG_QUEUE_MAX_SIZE) {
             if ($this->quitOnExitSignal && in_array($signal, array(SIGINT, SIGTERM))) {
                 $this->log("Received {$signal}: short circuiting QUIT waitpid");
-                $this->exit(1); // TODO: should this return a failed exit code?
+                $this->_exit(1); // TODO: should this return a failed exit code?
             }
 
             $this->sigQueue[] = $signal;

--- a/lib/Resque/Pool/Platform.php
+++ b/lib/Resque/Pool/Platform.php
@@ -17,12 +17,14 @@ class Platform
 {
     private static $SIG_QUEUE_MAX_SIZE = 5;
 
-    // @param Logger
+    /** @var Logger */
     protected $logger;
-    // @param bool
+    /** @var bool */
     private $quitOnExitSignal;
 
+    /** @var list<int> */
     private $sigQueue = array();
+    /** @var list<int> */
     private $trappedSignals = array();
 
     public function setLogger(Logger $logger = null)

--- a/lib/Resque/Pool/Pool.php
+++ b/lib/Resque/Pool/Pool.php
@@ -222,7 +222,7 @@ class Pool
 
     public function shutdownEverythingNow($signal)
     {
-        $this->logger->log("{$signal}: {$immediate} shutdown (and immediate worker shutdown)");
+        $this->logger->log("{$signal}: immediate shutdown (and immediate worker shutdown)");
         $this->signalAllWorkers(SIGTERM);
     }
 

--- a/lib/Resque/Pool/Pool.php
+++ b/lib/Resque/Pool/Pool.php
@@ -24,6 +24,10 @@ class Pool
      * @var Logger
      */
     private $logger;
+    /**
+     * @var Platform
+     */
+    private $platform;
 
     /**
      * @var array<string,array<int,true>>
@@ -264,7 +268,7 @@ class Pool
         $pid = $this->platform->pcntl_fork();
         if ($pid === -1) {
             $this->logger->log('pcntl_fork failed');
-            $this->platform->exit(1);
+            $this->platform->_exit(1);
         } elseif ($pid === 0) {
             $this->platform->releaseSignals();
             $worker = $this->createWorker($queues);

--- a/lib/Resque/Pool/Pool.php
+++ b/lib/Resque/Pool/Pool.php
@@ -13,6 +13,9 @@ namespace Resque\Pool;
  */
 class Pool
 {
+    /**
+     * @var list<int>
+     */
     private static $QUEUE_SIGS = array(SIGQUIT, SIGINT, SIGTERM, SIGUSR1, SIGUSR2, SIGCONT, SIGHUP, SIGWINCH, SIGCHLD);
 
     /**
@@ -41,6 +44,9 @@ class Pool
         $this->platform = $config->platform;
     }
 
+    /**
+     * @return void
+     */
     public function start()
     {
         $this->config->initialize();
@@ -53,6 +59,9 @@ class Pool
         $this->reportWorkerPoolPids();
     }
 
+    /**
+     * @return void
+     */
     public function join()
     {
         while (true) {
@@ -78,6 +87,8 @@ class Pool
     protected function handleSignalQueue()
     {
         switch ($signal = $this->platform->nextSignal()) {
+        case null:
+            break;
         case SIGUSR1:
         case SIGUSR2:
         case SIGCONT:
@@ -128,6 +139,9 @@ class Pool
         return false;
     }
 
+    /**
+     * @return void
+     */
     public function reportWorkerPoolPids()
     {
         if (count($this->workers) === 0) {
@@ -140,6 +154,7 @@ class Pool
 
     /**
      * Creates or shuts down workers to match the configured worker counts.
+     * @return void
      */
     public function maintainWorkerCount()
     {
@@ -160,6 +175,7 @@ class Pool
      * Finds and unsets dead workers.
      *
      * @param boolean $wait When true waits for all children to shutdown.
+     * @return void
      */
     public function reapAllWorkers($wait = false)
     {
@@ -171,6 +187,7 @@ class Pool
     }
 
     /**
+     * @param int $pid
      * @return string|null The queues $pid was created to work on
      */
     public function workerQueues($pid)
@@ -185,7 +202,7 @@ class Pool
     }
 
     /**
-     * @return [integer] The pids of all living worker daemons
+     * @return list<int> The pids of all living worker daemons
      */
     public function allPids()
     {
@@ -198,19 +215,30 @@ class Pool
             $result[] = array_keys($queues);
         }
 
-        return call_user_func_array('array_merge', $result);
+        return call_user_func_array('array_merge', $result); // @phpstan-ignore-line
     }
 
+    /**
+     * @return list<string>
+     */
     public function allKnownQueues()
     {
         return array_unique(array_merge($this->config->knownQueues(), array_keys($this->workers)));
     }
 
+    /**
+     * @param int $signal
+     * @return void
+     */
     public function signalAllWorkers($signal)
     {
         $this->platform->signalPids($this->allPids(), $signal);
     }
 
+    /**
+     * @param int $signal
+     * @return void
+     */
     public function gracefulWorkerShutdownAndWait($signal)
     {
         $this->logger->log("{$signal}: graceful shutdown, waiting for children");
@@ -218,18 +246,30 @@ class Pool
         $this->reapAllWorkers(true); // will hang until all workers are shutdown
     }
 
+    /**
+     * @param int $signal
+     * @return void
+     */
     public function gracefulWorkerShutdown($signal)
     {
         $this->logger->log("{$signal}: immediate shutdown (graceful worker shutdown)");
         $this->signalAllWorkers(SIGQUIT);
     }
 
+    /**
+     * @param int $signal
+     * @return void
+     */
     public function shutdownEverythingNow($signal)
     {
         $this->logger->log("{$signal}: immediate shutdown (and immediate worker shutdown)");
         $this->signalAllWorkers(SIGTERM);
     }
 
+    /**
+     * @param string $queues
+     * @return int
+     */
     protected function workerDeltaFor($queues)
     {
         $max = $this->config->workerCount($queues);
@@ -238,11 +278,19 @@ class Pool
         return $max - $active;
     }
 
+    /**
+     * @param string $queues
+     * @return int[]
+     */
     protected function pidsFor($queues)
     {
         return isset($this->workers[$queues]) ? array_keys($this->workers[$queues]) : array();
     }
 
+    /**
+     * @param int $pid
+     * @return void
+     */
     protected function deleteWorker($pid)
     {
         foreach (array_keys($this->workers) as $queues) {
@@ -262,6 +310,8 @@ class Pool
      *       code pre-fork so that the copy-on-write functionality of the linux memory model
      *       can share the compiled code between workers.  Some investigation into the facts
      *       would be usefull
+     * @param string $queues
+     * @return void
      */
     protected function spawnWorker($queues)
     {
@@ -275,13 +325,17 @@ class Pool
             $this->logger->logWorker("Starting worker {$worker}");
             $this->logger->procline("Starting worker {$worker}");
             $this->callAfterPrefork($worker);
-            $worker->work($this->config->workerInterval);
+            $worker->work($this->config->workerInterval); // @phpstan-ignore-line
             $this->platform->_exit(0);
         } else {
             $this->workers[$queues][$pid] = true;
         }
     }
 
+    /**
+     * @param object $worker
+     * @return void
+     */
     protected function callAfterPrefork($worker)
     {
         if ($callable = $this->config->afterPreFork) {
@@ -289,15 +343,19 @@ class Pool
         }
     }
 
+    /**
+     * @param string $queues
+     * @return object
+     */
     protected function createWorker($queues)
     {
         $queues = explode(',', $queues);
         $class = $this->config->workerClass;
         $worker = new $class($queues);
         if ($this->config->logLevel === Configuration::LOG_VERBOSE) {
-            $worker->logLevel = \Resque_Worker::LOG_VERBOSE;
+            $worker->logLevel = \Resque_Worker::LOG_VERBOSE; // @phpstan-ignore-line
         } elseif ($this->config->logLevel === Configuration::LOG_NORMAL) {
-            $worker->logLevel = \Resque_Worker::LOG_NORMAL;
+            $worker->logLevel = \Resque_Worker::LOG_NORMAL; // @phpstan-ignore-line
         }
 
         return $worker;

--- a/lib/Resque/Pool/Pool.php
+++ b/lib/Resque/Pool/Pool.php
@@ -16,17 +16,17 @@ class Pool
     private static $QUEUE_SIGS = array(SIGQUIT, SIGINT, SIGTERM, SIGUSR1, SIGUSR2, SIGCONT, SIGHUP, SIGWINCH, SIGCHLD);
 
     /**
-     * @param Configuration
+     * @var Configuration
      */
     private $config;
 
     /**
-     * @param Logger
+     * @var Logger
      */
     private $logger;
 
     /**
-     * @param [queues => [pid => true]]
+     * @var array<string,array<int,true>>
      */
     private $workers = array();
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+	level: max
+	paths:
+		- lib


### PR DESCRIPTION
This PR contains the following changes.

 - The method `Platform::_exit` was referenced as `Platform::exit` at a few places.
 - The package already depends on the short array syntax, which requires PHP 5.4+. So I have updated the minimum required version from PHP 5.4 to 5.4.
 - Fixed incorrect/non-standard phpdoc syntax for some of the methods / properties.
 - Added typehint for all methods, so that the code can be statically analyzed with PHPStan
 - Add Symfony 6.0 to supported versions

There is no backward incompatibility. If required, I can split the PR into multiple PRs.